### PR TITLE
make mirage-unix an optional dependency

### DIFF
--- a/_tags
+++ b/_tags
@@ -2,7 +2,7 @@ true : bin_annot, safe_string, package(bytes)
 
 # THE BLUEPRINT!
 <src>: include
-<src/**>: package(mirage-unix)
+<src/**>: package(lwt)
 
 <unix>: include
 <unix/**>: package(mirage-unix)

--- a/opam
+++ b/opam
@@ -17,10 +17,11 @@ depends: [
   "ocamlfind" {build}
   "ocamlbuild" {build}
   "topkg" {build}
-  "mirage-unix"
+  "lwt"
 ]
 depopts: [
   "mirage-solo5"
   "mirage-xen"
+  "mirage-unix"
 ]
 available: [ ocaml-version >= "4.01.0"]


### PR DESCRIPTION
all `src/` needs is Lwt (due to its usage of Lwt.t)