### PR TITLE
remove OS.Env, which was only ever implemented by the UNIX backend.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,12 +5,13 @@ sudo: required
 env:
   global:
     - PACKAGE="mirage-os-shim"
-    - PINS="depext:0.9.1 mirage-unix:git://github.com/mirage/mirage-platform.git mirage-xen:git://github.com/mirage/mirage-platform.git"
-    - DEPOPTS=mirage-xen
   matrix:
-    - OCAML_VERSION=4.01
-    - OCAML_VERSION=4.02
-    - OCAML_VERSION=4.03
+    - OCAML_VERSION=4.03 DEPOPTS=mirage-xen
+    - OCAML_VERSION=4.04 DEPOPTS=mirage-xen
+    - OCAML_VERSION=4.03 DEPOPTS=mirage-unix
+    - OCAML_VERSION=4.04 DEPOPTS=mirage-unix
+    - OCAML_VERSION=4.03 DEPOPTS=mirage-solo5
+    - OCAML_VERSION=4.04 DEPOPTS=mirage-solo5
 notifications:
   email: false
 

--- a/src/mirage_OS.ml
+++ b/src/mirage_OS.ml
@@ -2,7 +2,6 @@
    See LICENSE.md. *)
 
 module OS = struct
-  module Env = OS.Env
   module Lifecycle = OS.Lifecycle
   module Main = OS.Main
   module Time = OS.Time

--- a/src/mirage_OS.mli
+++ b/src/mirage_OS.mli
@@ -20,10 +20,6 @@
 let _ = OS.Main.at_enter ...]} *)
 module OS : sig
 
-  module Env : sig
-    val argv: unit -> (string array) Lwt.t
-  end
-
   module Lifecycle : sig
     val await_shutdown_request :
       ?can_poweroff:bool ->


### PR DESCRIPTION
There is a way to get boot parameters, using mirage-bootvar-{xen/unix/solo5}
and the default_argv device provided by Mirage

see https://github.com/mirage/mirage-solo5/pull/18 and https://github.com/mirage/mirage-platform/pull/187