### PR TITLE
OCaml 4.06.0 passes "-keep-locs" by default, which leads to path-depent .cmi

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,12 +5,15 @@ sudo: required
 env:
   global:
     - PACKAGE="mirage-os-shim"
-    - PINS="depext:0.9.1 mirage-unix:git://github.com/mirage/mirage-platform.git mirage-xen:git://github.com/mirage/mirage-platform.git"
-    - DEPOPTS=mirage-xen
   matrix:
-    - OCAML_VERSION=4.01
-    - OCAML_VERSION=4.02
-    - OCAML_VERSION=4.03
+    - OCAML_VERSION=4.04 DEPOPTS=mirage-xen
+    - OCAML_VERSION=4.04 DEPOPTS=mirage-unix
+    - OCAML_VERSION=4.04 DEPOPTS=mirage-solo5
+    - OCAML_VERSION=4.05 DEPOPTS=mirage-xen
+    - OCAML_VERSION=4.05 DEPOPTS=mirage-unix
+    - OCAML_VERSION=4.05 DEPOPTS=mirage-solo5
+    - OCAML_VERSION=4.06 DEPOPTS=mirage-unix
+    - OCAML_VERSION=4.06 DEPOPTS=mirage-solo5
 notifications:
   email: false
 

--- a/myocamlbuild.ml
+++ b/myocamlbuild.ml
@@ -2,6 +2,8 @@ open Ocamlbuild_plugin;;
 
 let () = dispatch @@ function
   | After_rules ->
+      if Sys.ocaml_version >= "4.06.0" then
+        flag ["ocaml"; "compile"] (A "-no-keep-locs");
       copy_rule "unix" "src/%" "unix/%";
       copy_rule "xen" "src/%" "xen/%";
       copy_rule "solo5" "src/%" "solo5/%";

--- a/opam
+++ b/opam
@@ -26,7 +26,7 @@ depopts: [
 ]
 available: [ ocaml-version >= "4.01.0"]
 conflicts: [
-  "mirage-unix" {<"3.0.0"}
-  "mirage-xen" {<"3.0.0"}
-  "mirage-solo5" {<"0.2.0"}
+  "mirage-unix" {< "3.0.0"}
+  "mirage-xen" {< "3.0.0"}
+  "mirage-solo5" {< "0.2.0"}
 ]

--- a/opam
+++ b/opam
@@ -25,3 +25,8 @@ depopts: [
   "mirage-unix"
 ]
 available: [ ocaml-version >= "4.01.0"]
+conflicts: [
+  "mirage-unix" {<"3.0.0"}
+  "mirage-xen" {<"3.0.0"}
+  "mirage-solo5" {<"0.2.0"}
+]


### PR DESCRIPTION
from the Changes in OCaml:
- MPR#7575, GPR#1219: Switch compilers from -no-keep-locs
  to -keep-locs by default: produced .cmi files will contain locations.
  This provides better error messages. Note that, as a consequence,
  .cmi digests now depend on the file path as given to the compiler.
  (Daniel Bünzli)

Now, mirage-os-shim uses some copy rules, and together with keep-locs this leads
to inconsistent assumptions when linking a unikernel.  The fix provided passes
"-no-keep-locs" in the 4.06.0+ case.

without this change I'm not able to compile mirage solo5 unikernels which use mirage-entropy with 4.06.0.