### PR TITLE
OCaml 4.06.0 passes "-keep-locs" by default, which leads to path-depe…

### DIFF
--- a/myocamlbuild.ml
+++ b/myocamlbuild.ml
@@ -2,6 +2,8 @@ open Ocamlbuild_plugin;;
 
 let () = dispatch @@ function
   | After_rules ->
+      if Sys.ocaml_version >= "4.06.0" then
+        flag ["ocaml"; "compile"] (A "-no-keep-locs");
       copy_rule "unix" "src/%" "unix/%";
       copy_rule "xen" "src/%" "xen/%";
       copy_rule "solo5" "src/%" "solo5/%";


### PR DESCRIPTION
…ndent .cmi

from the Changes in OCaml:
- MPR#7575, GPR#1219: Switch compilers from -no-keep-locs
  to -keep-locs by default: produced .cmi files will contain locations.
  This provides better error messages. Note that, as a consequence,
  .cmi digests now depend on the file path as given to the compiler.
  (Daniel Bünzli)

Now, mirage-os-shim uses some copy rules, and together with keep-locs this leads
to inconsistent assumptions when linking a unikernel.  The fix provided passes
"-no-keep-locs" in the 4.06.0+ case.